### PR TITLE
HYDRAN-2345: Fix Identifier type stored as UPPER_UNDERSCORE instead of camelCase

### DIFF
--- a/src/integration-test/resources/ConversationsIT/__files/test02_createConversation/response.json
+++ b/src/integration-test/resources/ConversationsIT/__files/test02_createConversation/response.json
@@ -5,7 +5,7 @@
 			"content": "Konversation skapad",
 			"created": "${json-unit.any-string}",
 			"createdBy": {
-				"type": "AD_ACCOUNT",
+				"type": "adAccount",
 				"value": "joe01doe"
 			},
 			"id": "${json-unit.any-string}",

--- a/src/main/java/se/sundsvall/messageexchange/service/MessageService.java
+++ b/src/main/java/se/sundsvall/messageexchange/service/MessageService.java
@@ -150,7 +150,7 @@ public class MessageService {
 	}
 
 	private boolean identifierNotPresent(final Stream<IdentifierEntity> identifierEntityStream) {
-		return identifierEntityStream.noneMatch(identifier -> identifier.getType().equals(Identifier.get().getType().name()) &&
+		return identifierEntityStream.noneMatch(identifier -> identifier.getType().equals(Identifier.get().getTypeString()) &&
 			identifier.getValue().equals(Identifier.get().getValue()));
 	}
 }

--- a/src/main/java/se/sundsvall/messageexchange/service/mapper/Mapper.java
+++ b/src/main/java/se/sundsvall/messageexchange/service/mapper/Mapper.java
@@ -287,7 +287,7 @@ public final class Mapper {
 
 		return Optional.ofNullable(identifier)
 			.map(p -> IdentifierEntity.create()
-				.withType(p.getType().name())
+				.withType(p.getTypeString())
 				.withValue(p.getValue()))
 			.orElse(null);
 	}

--- a/src/main/resources/db/migration/V1_3__backfill_identifier_type_to_camel_case.sql
+++ b/src/main/resources/db/migration/V1_3__backfill_identifier_type_to_camel_case.sql
@@ -1,0 +1,5 @@
+-- Backfill identifier.type from UPPER_UNDERSCORE to camelCase to match the OpenAPI contract.
+-- Previously stored via Identifier.Type.name() (e.g. "AD_ACCOUNT"); now stored via
+-- Identifier.getTypeString() (e.g. "adAccount").
+update identifier set type = 'adAccount' where type = 'AD_ACCOUNT';
+update identifier set type = 'partyId' where type = 'PARTY_ID';

--- a/src/test/java/se/sundsvall/messageexchange/service/ConversationServiceTest.java
+++ b/src/test/java/se/sundsvall/messageexchange/service/ConversationServiceTest.java
@@ -126,7 +126,7 @@ class ConversationServiceTest {
 			assertThat(message.getConversation()).isSameAs(entity);
 			assertThat(message.getSequenceNumber()).isNotNull();
 			assertThat(message.getContent()).isEqualTo("Konversation skapad");
-			assertThat(message.getCreatedBy().getType()).isEqualTo(Identifier.Type.AD_ACCOUNT.toString());
+			assertThat(message.getCreatedBy().getType()).isEqualTo("adAccount");
 			assertThat(message.getCreatedBy().getValue()).isEqualTo("adUser");
 		});
 	}
@@ -179,7 +179,7 @@ class ConversationServiceTest {
 			assertThat(message.getConversation()).isSameAs(entity);
 			assertThat(message.getSequenceNumber()).isNotNull();
 			assertThat(message.getContent()).isEqualTo("Ämnesrad ändrad från 'y' till 'x'.");
-			assertThat(message.getCreatedBy().getType()).isEqualTo(Identifier.Type.AD_ACCOUNT.toString());
+			assertThat(message.getCreatedBy().getType()).isEqualTo("adAccount");
 			assertThat(message.getCreatedBy().getValue()).isEqualTo("adUser");
 		});
 	}

--- a/src/test/java/se/sundsvall/messageexchange/service/MessageServiceTest.java
+++ b/src/test/java/se/sundsvall/messageexchange/service/MessageServiceTest.java
@@ -50,7 +50,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static se.sundsvall.dept44.support.Identifier.Type.AD_ACCOUNT;
 import static se.sundsvall.dept44.support.Identifier.Type.PARTY_ID;
 
 @ExtendWith(MockitoExtension.class)
@@ -120,7 +119,7 @@ class MessageServiceTest {
 			verify(conversationRepositoryMock).save(conversationEntityCaptor.capture());
 			assertThat(conversationEntityCaptor.getValue().getParticipants())
 				.hasSize(1).extracting(IdentifierEntity::getType, IdentifierEntity::getValue)
-				.containsExactly(Tuple.tuple(PARTY_ID.name(), "da012da"));
+				.containsExactly(Tuple.tuple("partyId", "da012da"));
 		}
 	}
 
@@ -151,7 +150,7 @@ class MessageServiceTest {
 		final var conversationId = "conversationId";
 		final var pageable = PageRequest.of(0, 10);
 		final var conversationEntity = new ConversationEntity();
-		final var messageEntity = new MessageEntity().withReadBy(new ArrayList<>(List.of(ReadByEntity.create().withIdentifier(IdentifierEntity.create().withType(PARTY_ID.name()).withValue("ad012ad")))));
+		final var messageEntity = new MessageEntity().withReadBy(new ArrayList<>(List.of(ReadByEntity.create().withIdentifier(IdentifierEntity.create().withType("partyId").withValue("ad012ad")))));
 		final var messagePage = new PageImpl<>(List.of(messageEntity), pageable, 1);
 		final var filter = MessageSpecificationBuilder.withConversation(conversationEntity);
 
@@ -189,7 +188,7 @@ class MessageServiceTest {
 		final var conversationId = "conversationId";
 		final var pageable = PageRequest.of(0, 10);
 		final var conversationEntity = new ConversationEntity();
-		final var messageEntity = new MessageEntity().withReadBy(new ArrayList<>(List.of(ReadByEntity.create().withIdentifier(IdentifierEntity.create().withType(PARTY_ID.name()).withValue("value")))));
+		final var messageEntity = new MessageEntity().withReadBy(new ArrayList<>(List.of(ReadByEntity.create().withIdentifier(IdentifierEntity.create().withType("partyId").withValue("value")))));
 		final var messagePage = new PageImpl<>(List.of(messageEntity), pageable, 1);
 		final var filter = MessageSpecificationBuilder.withConversation(conversationEntity);
 
@@ -362,7 +361,7 @@ class MessageServiceTest {
 		// Arrange
 		final var identifier = Identifier.create().withValue("testIdentifier").withType(PARTY_ID);
 
-		final var messageEntity = new MessageEntity().withReadBy(new ArrayList<>(List.of(ReadByEntity.create().withIdentifier(IdentifierEntity.create().withType(AD_ACCOUNT.name()).withValue("existingIdentifier")))));
+		final var messageEntity = new MessageEntity().withReadBy(new ArrayList<>(List.of(ReadByEntity.create().withIdentifier(IdentifierEntity.create().withType("adAccount").withValue("existingIdentifier")))));
 		final var messagePage = new PageImpl<>(List.of(messageEntity));
 
 		try (final var mockedStatic = mockStatic(Identifier.class)) {
@@ -375,9 +374,9 @@ class MessageServiceTest {
 			assertThat(messageEntity.getReadBy()).isNotNull();
 			assertThat(messageEntity.getReadBy()).hasSize(2);
 			assertThat(messageEntity.getReadBy().getFirst().getIdentifier().getValue()).isEqualTo("existingIdentifier");
-			assertThat(messageEntity.getReadBy().getFirst().getIdentifier().getType()).isEqualTo(AD_ACCOUNT.name());
+			assertThat(messageEntity.getReadBy().getFirst().getIdentifier().getType()).isEqualTo("adAccount");
 			assertThat(messageEntity.getReadBy().getLast().getIdentifier().getValue()).isEqualTo("testIdentifier");
-			assertThat(messageEntity.getReadBy().getLast().getIdentifier().getType()).isEqualTo(PARTY_ID.name());
+			assertThat(messageEntity.getReadBy().getLast().getIdentifier().getType()).isEqualTo("partyId");
 		}
 	}
 

--- a/src/test/java/se/sundsvall/messageexchange/service/mapper/MapperTest.java
+++ b/src/test/java/se/sundsvall/messageexchange/service/mapper/MapperTest.java
@@ -19,14 +19,15 @@ import se.sundsvall.messageexchange.integration.db.model.MetadataEntity;
 import se.sundsvall.messageexchange.integration.db.model.ReadByEntity;
 import se.sundsvall.messageexchange.integration.db.model.SequenceEntity;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mockStatic;
 import static se.sundsvall.dept44.support.Identifier.Type.PARTY_ID;
 
 @ExtendWith(MockitoExtension.class)
 class MapperTest {
+
+	private static final OffsetDateTime READ_AT = OffsetDateTime.parse("2025-01-01T12:00:00Z");
 
 	@Test
 	void toConversations() {
@@ -565,14 +566,18 @@ class MapperTest {
 			.withType(PARTY_ID)
 			.withValue(value);
 
-		// Act
-		final var result = Mapper.toReadByEntity(identifier);
+		try (final var mockedTime = mockStatic(OffsetDateTime.class, CALLS_REAL_METHODS)) {
+			mockedTime.when(OffsetDateTime::now).thenReturn(READ_AT);
 
-		// Assert
-		assertThat(result).isNotNull().hasNoNullFieldsOrPropertiesExcept("id");
-		assertThat(result.getIdentifier().getType()).isEqualTo(type);
-		assertThat(result.getIdentifier().getValue()).isEqualTo(value);
-		assertThat(result.getReadAt()).isCloseTo(OffsetDateTime.now(), within(5, SECONDS));
+			// Act
+			final var result = Mapper.toReadByEntity(identifier);
+
+			// Assert
+			assertThat(result).isNotNull().hasNoNullFieldsOrPropertiesExcept("id");
+			assertThat(result.getIdentifier().getType()).isEqualTo(type);
+			assertThat(result.getIdentifier().getValue()).isEqualTo(value);
+			assertThat(result.getReadAt()).isEqualTo(READ_AT);
+		}
 	}
 
 	@Test
@@ -594,7 +599,7 @@ class MapperTest {
 			.withIdentifier(Identifier.create()
 				.withType(type)
 				.withValue(value))
-			.withReadAt(OffsetDateTime.now());
+			.withReadAt(READ_AT);
 
 		// Act
 		final var result = Mapper.toReadByEntities(List.of(readBy));
@@ -604,7 +609,7 @@ class MapperTest {
 		assertThat(result.getFirst()).isNotNull().hasNoNullFieldsOrPropertiesExcept("id");
 		assertThat(result.getFirst().getIdentifier().getType()).isEqualTo(type);
 		assertThat(result.getFirst().getIdentifier().getValue()).isEqualTo(value);
-		assertThat(result.getFirst().getReadAt()).isCloseTo(OffsetDateTime.now(), within(5, SECONDS));
+		assertThat(result.getFirst().getReadAt()).isEqualTo(READ_AT);
 	}
 
 	@Test
@@ -635,7 +640,7 @@ class MapperTest {
 			.withIdentifier(Identifier.create()
 				.withType(type)
 				.withValue(value))
-			.withReadAt(OffsetDateTime.now());
+			.withReadAt(READ_AT);
 
 		// Act
 		final var result = Mapper.toReadByEntity(readBy);
@@ -644,7 +649,7 @@ class MapperTest {
 		assertThat(result).isNotNull().hasNoNullFieldsOrPropertiesExcept("id");
 		assertThat(result.getIdentifier().getType()).isEqualTo(type);
 		assertThat(result.getIdentifier().getValue()).isEqualTo(value);
-		assertThat(result.getReadAt()).isCloseTo(OffsetDateTime.now(), within(5, SECONDS));
+		assertThat(result.getReadAt()).isEqualTo(READ_AT);
 	}
 
 	@Test
@@ -666,7 +671,7 @@ class MapperTest {
 			.withIdentifier(IdentifierEntity.create()
 				.withType(type)
 				.withValue(value))
-			.withReadAt(OffsetDateTime.now());
+			.withReadAt(READ_AT);
 
 		// Act
 		final var result = Mapper.toReadByList(List.of(readByEntity));
@@ -676,7 +681,7 @@ class MapperTest {
 		assertThat(result.getFirst()).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(result.getFirst().getIdentifier().getType()).isEqualTo(type);
 		assertThat(result.getFirst().getIdentifier().getValue()).isEqualTo(value);
-		assertThat(result.getFirst().getReadAt()).isCloseTo(OffsetDateTime.now(), within(5, SECONDS));
+		assertThat(result.getFirst().getReadAt()).isEqualTo(READ_AT);
 	}
 
 	@Test
@@ -707,7 +712,7 @@ class MapperTest {
 			.withIdentifier(IdentifierEntity.create()
 				.withType(type)
 				.withValue(value))
-			.withReadAt(OffsetDateTime.now());
+			.withReadAt(READ_AT);
 
 		// Act
 		final var result = Mapper.toReadBy(readByEntity);
@@ -716,7 +721,7 @@ class MapperTest {
 		assertThat(result).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(result.getIdentifier().getType()).isEqualTo(type);
 		assertThat(result.getIdentifier().getValue()).isEqualTo(value);
-		assertThat(result.getReadAt()).isCloseTo(OffsetDateTime.now(), within(5, SECONDS));
+		assertThat(result.getReadAt()).isEqualTo(READ_AT);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/messageexchange/service/mapper/MapperTest.java
+++ b/src/test/java/se/sundsvall/messageexchange/service/mapper/MapperTest.java
@@ -263,7 +263,7 @@ class MapperTest {
 	void toMessageEntity() {
 		// Arrange
 		final var inReplyTo = "inReplyTo";
-		final var createdByType = "PARTY_ID";
+		final var createdByType = "partyId";
 		final var createdByValue = "value";
 		final var content = "content";
 		final var dept44Identifier = se.sundsvall.dept44.support.Identifier.create()
@@ -510,7 +510,7 @@ class MapperTest {
 	void toReadByEntitiesFromDept44Identifier() {
 
 		// Arrange
-		final var type = "PARTY_ID";
+		final var type = "partyId";
 		final var value = "value";
 		final var identifier = se.sundsvall.dept44.support.Identifier.create()
 			.withType(PARTY_ID)
@@ -529,7 +529,7 @@ class MapperTest {
 	@Test
 	void toIdentifierEntityFromDept44Identifier() {
 		// Arrange
-		final var type = "PARTY_ID";
+		final var type = "partyId";
 		final var value = "value";
 
 		final var identifier = se.sundsvall.dept44.support.Identifier.create()
@@ -558,7 +558,7 @@ class MapperTest {
 	@Test
 	void toReadByEntityFromDept44Identifier() {
 		// Arrange
-		final var type = "PARTY_ID";
+		final var type = "partyId";
 		final var value = "value";
 
 		final var identifier = se.sundsvall.dept44.support.Identifier.create()
@@ -587,7 +587,7 @@ class MapperTest {
 	@Test
 	void toReadByListEntityFromReadByList() {
 		// Arrange
-		final var type = "PARTY_ID";
+		final var type = "partyId";
 		final var value = "value";
 
 		final var readBy = ReadBy.create()
@@ -628,7 +628,7 @@ class MapperTest {
 	@Test
 	void toReadByEntityFromReadByList() {
 		// Arrange
-		final var type = "PARTY_ID";
+		final var type = "partyId";
 		final var value = "value";
 
 		final var readBy = ReadBy.create()
@@ -659,7 +659,7 @@ class MapperTest {
 	@Test
 	void toReadByList() {
 		// Arrange
-		final var type = "PARTY_ID";
+		final var type = "partyId";
 		final var value = "value";
 
 		final var readByEntity = ReadByEntity.create()
@@ -700,7 +700,7 @@ class MapperTest {
 	@Test
 	void toReadBy() {
 		// Arrange
-		final var type = "PARTY_ID";
+		final var type = "partyId";
 		final var value = "value";
 
 		final var readByEntity = ReadByEntity.create()


### PR DESCRIPTION
## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Description

The OpenAPI contract declares `Identifier.type` with `pattern: ^(adAccount|partyId)$`, and the input `@Pattern` validator on the API model enforces this. The internal `Mapper.toIdentifierEntity`, however, persisted via `Identifier.Type.name()` (`"AD_ACCOUNT"` / `"PARTY_ID"`), so responses returned `UPPER_UNDERSCORE` values — breaking the contract for downstream consumers.

This was a latent bug that worked only because output isn't pattern-validated. Consumers that follow the spec (e.g. `api-service-case-data`, `api-service-support-management`) couldn't map the type to its semantic meaning (channel, participant comparison, etc).

### Changes

- `service/mapper/Mapper.java` — `.getType().name()` → `.getTypeString()` in `toIdentifierEntity(dept44.Identifier)`
- `service/MessageService.java` — `Identifier.get().getType().name()` → `.getTypeString()` in `identifierNotPresent`
- `db/migration/V1_3__backfill_identifier_type_to_camel_case.sql` — backfills existing rows: `'AD_ACCOUNT' → 'adAccount'`, `'PARTY_ID' → 'partyId'`
- Tests + fixtures aligned to the new (correct) format

### Impact analysis

- **API consumers** that follow the spec start receiving correctly formatted values — no client changes needed.
- **No filters/queries** on `identifier.type` exist (`MessageSpecificationBuilder` only filters on `conversation`), so no JPA logic breaks.
- **No events, webhooks or audit logic** depends on the type format.
- **`MessageEntity.type`** (`USER_CREATED`/`SYSTEM_CREATED`) is a separate enum field and is unaffected.

Not considered a breaking change because the OpenAPI contract has always declared camelCase as the legal output format — this aligns the implementation with the published contract.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).